### PR TITLE
Adding logging around zip extraction.

### DIFF
--- a/src/main/python/infra_buddy/template/template.py
+++ b/src/main/python/infra_buddy/template/template.py
@@ -84,15 +84,23 @@ class URLTemplate(Template):
         self._prep_download()
         r = requests.get(self.download_url, stream=True)
         if r.status_code != 200:
-            print_utility.error("Template cloud not be downloaded - {status} {body}".format(status=r.status_code,
-                                                                                            body=r.text))
+            print_utility.error("Template cloud not be downloaded. status: {status} body: {body}, url: {url}".format(
+                status=r.status_code,
+                body=r.text,
+                url=self.download_url,
+            ))
         temporary_file = tempfile.NamedTemporaryFile()
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks
                 temporary_file.write(chunk)
         temporary_file.seek(0)
-        with ZipFile(temporary_file) as zf:
-            zf.extractall(self.destination)
+        try:
+            with ZipFile(temporary_file) as zf:
+                zf.extractall(self.destination)
+        except Exception as e:
+            print_utility.error('Unable to process Zipfile. url: {url}'.format(url=self.download_url))
+            raise e
+
         self._validate_template_dir()
 
 


### PR DESCRIPTION
Getting the following error while deploying the OB projects:

```
error	28-Mar-2019 14:10:07	Traceback (most recent call last):
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/bin/infra-buddy", line 11, in <module>
error	28-Mar-2019 14:10:07	    sys.exit(commandline.cli())
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/click/core.py", line 764, in __call__
error	28-Mar-2019 14:10:07	    return self.main(*args, **kwargs)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/click/core.py", line 717, in main
error	28-Mar-2019 14:10:07	    rv = self.invoke(ctx)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
error	28-Mar-2019 14:10:07	    return _process_result(sub_ctx.command.invoke(sub_ctx))
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/click/core.py", line 956, in invoke
error	28-Mar-2019 14:10:07	    return ctx.invoke(self.callback, **ctx.params)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
error	28-Mar-2019 14:10:07	    return callback(*args, **kwargs)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/click/decorators.py", line 27, in new_func
error	28-Mar-2019 14:10:07	    return f(get_current_context().obj, *args, **kwargs)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/commands/deploy_service/command.py", line 20, in deploy_cloudformation
error	28-Mar-2019 14:10:07	    do_command(deploy_ctx, dry_run)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/commands/deploy_service/command.py", line 24, in do_command
error	28-Mar-2019 14:10:07	    plan = deploy_ctx.get_execution_plan()
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/context/deploy_ctx.py", line 206, in get_execution_plan
error	28-Mar-2019 14:10:07	    execution_plan = self.service_definition.generate_execution_plan(self.template_manager, self)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/context/service_definition.py", line 98, in generate_execution_plan
error	28-Mar-2019 14:10:07	    template = template_manager.get_known_service(self.service_type)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/template/template_manager.py", line 61, in get_known_service
error	28-Mar-2019 14:10:07	    return self.locate_service(service_type)
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/template/template_manager.py", line 104, in locate_service
error	28-Mar-2019 14:10:07	    template.download_template()
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/template/template.py", line 111, in download_template
error	28-Mar-2019 14:10:07	    self.delegate.download_template()
error	28-Mar-2019 14:10:07	  File "/mnt/bamboo-ebs/bamboo-agent/build-dir/288391169-288489473/venv/local/lib/python2.7/site-packages/infra_buddy/template/template.py", line 91, in download_template
error	28-Mar-2019 14:10:07	    with ZipFile(temporary_file) as zf:
error	28-Mar-2019 14:10:07	  File "/usr/lib/python2.7/zipfile.py", line 770, in __init__
error	28-Mar-2019 14:10:07	    self._RealGetContents()
error	28-Mar-2019 14:10:07	  File "/usr/lib/python2.7/zipfile.py", line 811, in _RealGetContents
error	28-Mar-2019 14:10:07	    raise BadZipfile, "File is not a zip file"
error	28-Mar-2019 14:10:07	zipfile.BadZipfile: File is not a zip file
build	28-Mar-2019 14:10:07	Starting next build stage...
```

I added some logging to see what URL is getting downloaded and inspect the URL.

The unit tests passed, but got an error with coverage, not sure why since I didn't make a change in command.

```
[INFO]  Executed 49 unit tests
[INFO]  All unit tests passed.
[WARN]  Test coverage below 70% for infra_buddy.commands.introspect.command: 58%
[WARN]  Branch coverage below 50% for infra_buddy.commands.introspect.command:  0%
[INFO]  Overall coverage is 88%
[INFO]  Overall coverage branch coverage is 72%
[INFO]  Overall coverage partial branch coverage is 82%
------------------------------------------------------------
BUILD FAILED - Test coverage for at least one module is below 70%
------------------------------------------------------------
```