### PR TITLE
Relative Path & Easy defaults

### DIFF
--- a/src/main/python/infra_buddy/aws/s3.py
+++ b/src/main/python/infra_buddy/aws/s3.py
@@ -64,7 +64,7 @@ class S3Buddy(object):
 
     def _get_upload_bucket_key_name(self, file, key_name=None):
         key_name = (key_name if key_name else os.path.basename(file))
-        if self.key_root_path and self.key_root_path is not '':
+        if self.key_root_path and self.key_root_path != '':
             return "{path}/{key_name}".format(path=self.key_root_path,
                                               key_name=key_name)
         return key_name

--- a/src/main/python/infra_buddy/context/deploy_ctx.py
+++ b/src/main/python/infra_buddy/context/deploy_ctx.py
@@ -147,7 +147,7 @@ class DeployContext(dict):
             self['REGION'] = 'us-west-1'
         self.template_manager = TemplateManager(self.get_deploy_templates(),self.get_service_modification_templates())
         self.stack_name_cache = []
-        if self.get('DATADOG_KEY','') is not '':
+        if self.get('DATADOG_KEY','') != '':
             self.notifier = DataDogNotifier(key=self['DATADOG_KEY'],deploy_context=self)
         else:
             self.notifier = None

--- a/src/main/python/infra_buddy/context/deploy_ctx.py
+++ b/src/main/python/infra_buddy/context/deploy_ctx.py
@@ -135,10 +135,7 @@ class DeployContext(dict):
         self['DATADOG_KEY'] = ""
         self['ENVIRONMENT'] = environment.lower() if environment else "dev"
         if defaults:
-            print_utility.info("Loading default settings from path: {}".format(defaults))
-            with open(defaults, 'r') as fp:
-                config = json.load(fp)
-                self.update(config)
+            self.update(defaults)
         self.update(os.environ)
         if 'REGION' not in self:
             print_utility.warn("Region not configured using default 'us-west-1'. "

--- a/src/main/python/infra_buddy/template/template.py
+++ b/src/main/python/infra_buddy/template/template.py
@@ -145,7 +145,10 @@ class GitHubTemplate(URLTemplate):
         super(GitHubTemplate, self).__init__(service_type=service_type, values=values)
         tag = values.pop('tag', 'master')
         self.download_url = "https://github.com/{owner}/{repo}/archive/{tag}.zip".format(tag=tag, **values)
-        self._set_download_relative_path("{repo}-{tag}".format(tag=tag, **values))
+        if 'relative-path' in values:
+            self._set_download_relative_path("{repo}-{tag}/{relative-path}".format(tag=tag, **values))
+        else:
+            self._set_download_relative_path("{repo}-{tag}".format(tag=tag, **values))
 
 
 class NamedLocalTemplate(Template):

--- a/src/main/python/infra_buddy/template/template_manager.py
+++ b/src/main/python/infra_buddy/template/template_manager.py
@@ -34,6 +34,7 @@ class TemplateManager(object):
                 "repo": {"type": "string"},
                 "tag": {"type": "string"},
                 "location": {"type": "string"},
+                "relative-path": {"type": "string"},
                 "url": {"type": "string"}
             },
             "required": ["type"]

--- a/src/unittest/python/commandline_tests.py
+++ b/src/unittest/python/commandline_tests.py
@@ -1,3 +1,5 @@
+import json
+
 import click
 
 from click.testing import CliRunner
@@ -9,6 +11,11 @@ from testcase_parent import ParentTestCase
 @click.pass_obj
 def test_method(deploy_ctx):
     click.echo(deploy_ctx.stack_name)
+
+@cli.command(name='env-echo')
+@click.pass_obj
+def env_echo(deploy_ctx):
+    click.echo(deploy_ctx['TEST'])
 
 
 class CommandlineTestCase(ParentTestCase):
@@ -22,14 +29,22 @@ class CommandlineTestCase(ParentTestCase):
     def test_context_creation(self):
         runner = CliRunner()
         result = runner.invoke(cli, ['--application', 'foo', '--role', 'bar', '--environment', 'unit-test',
-                                     '--configuration-defaults', self.default_config, 'test-command'])
+                                     '--configuration-defaults', self.default_config_path, 'test-command'])
         self.assertEqual(result.output.strip(), 'unit-test-foo-bar', "Invocation for simple cli usage failed")
+
+    def test_defaults_load(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("defaults.json", 'w') as fp:
+                json.dump({"TEST":"blazes"}, fp)
+            result = runner.invoke(cli, ['--application', 'foo', '--role', 'bar', '--environment', 'unit-test', 'env-echo'])
+        self.assertTrue('blazes' in result.output.strip() , "Invocation for default loading of defaults.json")
 
     def test_artifact_context_creation(self):
         artifact_directory = self._get_resource_path('artifact_directory_tests/artifact_service_definition')
         runner = CliRunner()
         result = runner.invoke(cli, ['--artifact-directory', artifact_directory, '--environment', 'unit-test',
-                                     '--configuration-defaults', self.default_config, 'test-command'])
+                                     '--configuration-defaults', self.default_config_path, 'test-command'])
         self.assertEqual(result.output.strip(), 'unit-test-foo-bar', "Invocation for simple cli usage failed")
 
     def test_error_case(self):
@@ -38,7 +53,7 @@ class CommandlineTestCase(ParentTestCase):
         result = runner.invoke(cli,
                                ['--application', 'foo', '--artifact-directory', artifact_directory, '--environment',
                                 'unit-test',
-                                '--configuration-defaults', self.default_config, 'test-command'])
+                                '--configuration-defaults', self.default_config_path, 'test-command'])
         self.assertEqual(result.exit_code, 2, "Failed to fail")
 
     def test_template_validate(self):

--- a/src/unittest/python/template_manager_tests.py
+++ b/src/unittest/python/template_manager_tests.py
@@ -33,7 +33,9 @@ class TemplateManagerTestCase(ParentTestCase):
         template = manager.get_known_service(service_name)
         self.assertIsNotNone(template, "Failed to locate service")
         self.assertIsNotNone(template.get_template_file_path(), "Failed to locate template file")
+        self.assertTrue(os.path.exists(template.get_template_file_path()),"Template does not exist in real life")
         self.assertIsNotNone(template.get_parameter_file_path(), "Failed to locate param file")
+        self.assertTrue(os.path.exists(template.get_parameter_file_path()),"Param file does not exist in real life")
         if has_config_dir:
             self.assertIsNotNone(template.get_config_dir(), "Failed to locate config dir")
 
@@ -45,6 +47,16 @@ class TemplateManagerTestCase(ParentTestCase):
                                     "type": "github",
                                     "owner": "AlienVault-Engineering",
                                     "repo": "infra-buddy-vpc"
+                                })
+    def test_github_relative_path_template(self):
+        self._validate_template(self.test_deploy_ctx.template_manager,
+                                service_name='vpc',
+                                has_config_dir=False,
+                                template_def={
+                                    "type": "github",
+                                    "owner": "rspitler",
+                                    "repo": "cloudformation-templates",
+                                    "relative-path":"vpc"
                                 })
 
     def test_invalid_github_template(self):

--- a/src/unittest/python/testcase_parent.py
+++ b/src/unittest/python/testcase_parent.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import string
@@ -10,6 +11,11 @@ from infra_buddy.utility import print_utility
 
 DIRNAME = os.path.dirname(os.path.abspath(__file__))
 RESOURCE_DIR = os.path.abspath(os.path.join(DIRNAME, '../resources/'))
+
+
+def load_path_as_json(path):
+    with open(path) as fp:
+        return json.load(fp)
 
 
 class ParentTestCase(unittest.TestCase):
@@ -25,8 +31,9 @@ class ParentTestCase(unittest.TestCase):
         super(ParentTestCase, cls).setUpClass()
         cls.resource_directory = RESOURCE_DIR
         cls.run_random_word = cls.randomWord(5)
-        cls.default_config = ParentTestCase._get_resource_path('default_config.json')
-        cls.east_config = ParentTestCase._get_resource_path('east_config.json')
+        cls.default_config_path = ParentTestCase._get_resource_path('default_config.json')
+        cls.default_config = load_path_as_json(ParentTestCase._get_resource_path('default_config.json'))
+        cls.east_config = load_path_as_json(ParentTestCase._get_resource_path('east_config.json'))
         cls.test_deploy_ctx = DeployContext.create_deploy_context(application="foo", role="bar-{}".format(cls.run_random_word), environment="unit-test",
                                             defaults=cls.default_config)
         print_utility.configure(False)


### PR DESCRIPTION
It gets pretty cumbersome to have a separate repo for each template.  This allows you to host multiple in a single repo at different relative paths.  