### PR TITLE
Fix bug preventing loading of service-modifications from defaults.json

### DIFF
--- a/src/main/python/infra_buddy/commands/validate_template/command.py
+++ b/src/main/python/infra_buddy/commands/validate_template/command.py
@@ -13,7 +13,7 @@ from infra_buddy.utility import print_utility
                                                                          "the service template.")
 @click.option("--service-type", help="The service-type of an internal template.")
 @click.pass_obj
-def deploy_cloudformation(deploy_ctx, service_template_directory, service_type):
+def validate_template(deploy_ctx, service_template_directory, service_type):
     # type: (DeployContext,str,str) -> None
     do_command(deploy_ctx, service_template_directory, service_type)
 
@@ -21,7 +21,7 @@ def deploy_cloudformation(deploy_ctx, service_template_directory, service_type):
 def do_command(deploy_ctx, service_template_directory=None, service_type=None):
     # type: (DeployContext,[str or None],str) -> None
     if service_template_directory is None:
-        print_utility.warn(
+        print_utility.info(
             "Service template directory was not provided.  Assuming service-type '{}' is built-in.".format(
                 service_type))
         template = deploy_ctx.template_manager.get_known_template(template_name=service_type)
@@ -33,3 +33,5 @@ def do_command(deploy_ctx, service_template_directory=None, service_type=None):
     errs = deploy.analyze()
     if errs > 0:
         print_utility.error("Template raised {} errors ".format(errs), raise_exception=True)
+    else:
+        print_utility.banner_warn("Service Template Validation - {}".format(service_type),"SUCCESS - No errors")

--- a/src/main/python/infra_buddy/context/deploy_ctx.py
+++ b/src/main/python/infra_buddy/context/deploy_ctx.py
@@ -88,8 +88,8 @@ class DeployContext(dict):
         if len(self.stack_name_cache)>0:
             print_utility.warn("Depth: {}".format(self.stack_name_cache))
         if self.current_deploy:
-            print_utility.banner_warn("Deploy Defaults:",pformat(self.current_deploy.defaults))
-        print_utility.banner_warn("Environment:",pformat(self))
+            print_utility.banner_info("Deploy Defaults:",pformat(self.current_deploy.defaults))
+        print_utility.banner_info("Environment:",pformat(self))
 
     def _initialize_artifact_directory(self, artifact_directory):
         # type: (str) -> None

--- a/src/main/python/infra_buddy/deploy/cloudformation_deploy.py
+++ b/src/main/python/infra_buddy/deploy/cloudformation_deploy.py
@@ -156,22 +156,22 @@ class CloudFormationDeploy(Deploy):
     def print_known_parameters(self):
         # type: (DeployContext) -> int
         known_param, warnings, errors = self._analyze_parameters()
-        print_utility.banner_info("Parameters", pformat(known_param))
+        print_utility.banner_info("Parameters Details", pformat(known_param))
         if warnings:
-            print_utility.banner_warn("Parameter Warnings", warnings)
+            print_utility.banner_warn("Parameter Warnings", pformat(warnings, indent=1))
 
         if errors:
-            print_utility.banner_warn("Parameter Errors", errors)
+            print_utility.banner_warn("Parameter Errors", pformat(errors, indent=1))
 
         return len(errors)
 
     def print_export(self):
         # type: () -> int
         known_exports, warnings, errors = self._analyze_export()
-        print_utility.banner_info("Export Values", known_exports)
+        print_utility.banner_info("Export Values", pformat(known_exports,indent=1))
 
         if errors:
-            print_utility.banner_warn("Export Values Errors", errors)
+            print_utility.banner_warn("Export Values Errors", pformat(errors, indent=1))
 
         return len(errors)
 

--- a/src/main/python/infra_buddy/template/template_manager.py
+++ b/src/main/python/infra_buddy/template/template_manager.py
@@ -55,7 +55,7 @@ class TemplateManager(object):
         self._load_templates(modification_templates_, service_modification=True)
         if user_default_service_templates: self._load_templates(user_default_service_templates)
         if user_default_service_modification_tempaltes: self._load_templates(
-            user_default_service_modification_tempaltes)
+            user_default_service_modification_tempaltes, service_modification=True)
 
     def get_known_service(self, service_type):
         # type: (str) -> Template

--- a/src/main/python/infra_buddy/utility/print_utility.py
+++ b/src/main/python/infra_buddy/utility/print_utility.py
@@ -31,7 +31,7 @@ def banner_info(msg, data):
 
 def banner_warn(msg, data):
     banner(msg)
-    info_banner(data)
+    click.secho(data, fg='green')
 
 
 def error(err_msg, raise_exception=False):

--- a/src/unittest/python/commandline_tests.py
+++ b/src/unittest/python/commandline_tests.py
@@ -59,4 +59,5 @@ class CommandlineTestCase(ParentTestCase):
     def test_template_validate(self):
         runner = CliRunner()
         result = runner.invoke(cli,[ 'validate-template' , "--service-type","cluster"])
-        # self.assertEqual(result.exit_code, 0, "Failed ")
+        self.assertEqual(result.exit_code, 0, "Failed ")
+        self.assertTrue("SUCCESS" in result.output, "Did not validate ")

--- a/src/unittest/python/template_manager_tests.py
+++ b/src/unittest/python/template_manager_tests.py
@@ -33,9 +33,9 @@ class TemplateManagerTestCase(ParentTestCase):
         template = manager.get_known_service(service_name)
         self.assertIsNotNone(template, "Failed to locate service")
         self.assertIsNotNone(template.get_template_file_path(), "Failed to locate template file")
-        self.assertTrue(os.path.exists(template.get_template_file_path()),"Template does not exist in real life")
+        self.assertTrue(os.path.exists(template.get_template_file_path()), "Template does not exist in real life")
         self.assertIsNotNone(template.get_parameter_file_path(), "Failed to locate param file")
-        self.assertTrue(os.path.exists(template.get_parameter_file_path()),"Param file does not exist in real life")
+        self.assertTrue(os.path.exists(template.get_parameter_file_path()), "Param file does not exist in real life")
         if has_config_dir:
             self.assertIsNotNone(template.get_config_dir(), "Failed to locate config dir")
 
@@ -48,6 +48,7 @@ class TemplateManagerTestCase(ParentTestCase):
                                     "owner": "AlienVault-Engineering",
                                     "repo": "infra-buddy-vpc"
                                 })
+
     def test_github_relative_path_template(self):
         self._validate_template(self.test_deploy_ctx.template_manager,
                                 service_name='vpc',
@@ -56,21 +57,20 @@ class TemplateManagerTestCase(ParentTestCase):
                                     "type": "github",
                                     "owner": "rspitler",
                                     "repo": "cloudformation-templates",
-                                    "relative-path":"vpc"
+                                    "relative-path": "vpc"
                                 })
 
     def test_invalid_github_template(self):
         try:
             self.test_deploy_ctx.template_manager._load_templates({'vpc': {
-                                                            "type": "github",
-                                                            "owner": "AlienVault-Engineering-Fail",
-                                                            "repo": "infra-buddy-vpc"
-                                                        }})
+                "type": "github",
+                "owner": "AlienVault-Engineering-Fail",
+                "repo": "infra-buddy-vpc"
+            }})
             template = self.test_deploy_ctx.template_manager.get_known_service('vpc')
             self.fail("Did not error on bad github template")
         except:
             pass
-
 
     def test_invalid_template(self):
         template = self.test_deploy_ctx.template_manager.get_resource_service(
@@ -123,13 +123,34 @@ class TemplateManagerTestCase(ParentTestCase):
     def test_service_mod_load(self):
         template_manager = TemplateManager()
         self.assertTrue(template_manager.get_known_template('cluster'), "Failed to locate known template")
-        self.assertTrue(template_manager.get_known_service_modification("foo", 'rds-aurora'), "Failed to locate wildcard service mod template")
-        self.assertTrue(template_manager.get_known_service_modification("batch-service", 'autoscale'), "Failed to locate multi type service mod template")
-        self.assertTrue(template_manager.get_known_service_modification("ecs-service", 'autoscale'), "Failed to locate multi type service mod template")
-        self.assertTrue(template_manager.get_known_service_modification("api-service", 'autoscale'), "Failed to locate multi type service mod template")
-        self.assertTrue(template_manager.get_known_service_modification("default-api-service", 'autoscale'), "Failed to locate multi type service mod template")
-        self.assertTrue(template_manager.get_known_template('autoscale'), "Failed to locate known template mod template")
-        self.assertTrue(template_manager.get_known_template('cluster'), "Failed to locate wildcard service mod template")
+        self.assertTrue(template_manager.get_known_service_modification("foo", 'rds-aurora'),
+                        "Failed to locate wildcard service mod template")
+        self.assertTrue(template_manager.get_known_service_modification("batch-service", 'autoscale'),
+                        "Failed to locate multi type service mod template")
+        self.assertTrue(template_manager.get_known_service_modification("ecs-service", 'autoscale'),
+                        "Failed to locate multi type service mod template")
+        self.assertTrue(template_manager.get_known_service_modification("api-service", 'autoscale'),
+                        "Failed to locate multi type service mod template")
+        self.assertTrue(template_manager.get_known_service_modification("default-api-service", 'autoscale'),
+                        "Failed to locate multi type service mod template")
+        self.assertTrue(template_manager.get_known_template('autoscale'),
+                        "Failed to locate known template mod template")
+        self.assertTrue(template_manager.get_known_template('cluster'),
+                        "Failed to locate wildcard service mod template")
+
+    def test_service_mod_defaults_load(self):
+        template_manager = TemplateManager(user_default_service_modification_tempaltes={
+            "secret": {
+                "type": "github",
+                "owner": "rspitler",
+                "repo": "cloudformation-templates",
+                "tag": "master/secret",
+                "compatible": [
+                    "*"
+                ]
+            }
+        })
+        self.assertTrue(template_manager.get_known_template('secret'), "Failed to locate default template")
 
     def test_service_alias(self):
         template_manager = TemplateManager()
@@ -145,4 +166,3 @@ class TemplateManagerTestCase(ParentTestCase):
         self.assertEquals(template.lookup, 'ecs-service', "Failed to locate ecs-service template delegate")
         deploy = CloudFormationDeploy("foo", template, deploy_ctx=self.test_deploy_ctx)
         self.assertTrue(deploy.defaults['CREATE_API'], "Did not populate expect default variables")
-


### PR DESCRIPTION
There was a missing flag when loading the service-modifications from default.json.

I also cleaned up the logging output so that you can get meaningful output without --verbose on validate-template and others